### PR TITLE
Fix manual collapse in Active/Ready tree view

### DIFF
--- a/internal/ui/app_viewmode_test.go
+++ b/internal/ui/app_viewmode_test.go
@@ -156,6 +156,52 @@ func TestViewModePreservesTreeHierarchy(t *testing.T) {
 	}
 }
 
+func TestViewModeActiveAllowsManualCollapseOfMatchingParent(t *testing.T) {
+	openChild := &graph.Node{
+		Issue: beads.FullIssue{ID: "ab-child", Title: "Open Child", Status: "open"},
+	}
+	deferredParent := &graph.Node{
+		Issue:    beads.FullIssue{ID: "ab-parent", Title: "Deferred Parent", Status: "deferred"},
+		Children: []*graph.Node{openChild},
+		Expanded: true,
+	}
+	openChild.Parent = deferredParent
+
+	app := &App{
+		roots:    []*graph.Node{deferredParent},
+		viewMode: ViewModeActive,
+		keys:     DefaultKeyMap(),
+	}
+
+	// Active mode keeps parent visible because child matches.
+	app.recalcVisibleRows()
+	if len(app.visibleRows) != 2 {
+		t.Fatalf("expected 2 visible rows before collapse, got %d", len(app.visibleRows))
+	}
+
+	parentRow := app.visibleRows[0]
+	if parentRow.Node.Issue.ID != "ab-parent" {
+		t.Fatalf("expected parent at row 0, got %s", parentRow.Node.Issue.ID)
+	}
+
+	// Manual collapse must override auto-expanded filter behavior.
+	app.collapseNodeForView(parentRow)
+	app.recalcVisibleRows()
+	if len(app.visibleRows) != 1 {
+		t.Fatalf("expected only parent visible after collapse, got %d rows", len(app.visibleRows))
+	}
+	if app.visibleRows[0].Node.Issue.ID != "ab-parent" {
+		t.Fatalf("expected parent to remain visible after collapse, got %s", app.visibleRows[0].Node.Issue.ID)
+	}
+
+	// Manual expand restores child visibility.
+	app.expandNodeForView(app.visibleRows[0])
+	app.recalcVisibleRows()
+	if len(app.visibleRows) != 2 {
+		t.Fatalf("expected parent and child visible after re-expand, got %d rows", len(app.visibleRows))
+	}
+}
+
 func TestViewModeReadyPreservesTreeHierarchy(t *testing.T) {
 	// Child is ready (open + not blocked), parent is closed
 	// ViewModeReady should show BOTH (parent shown because child matches)

--- a/internal/ui/state_expansion.go
+++ b/internal/ui/state_expansion.go
@@ -41,7 +41,7 @@ func (m *App) isNodeExpandedInView(row graph.TreeRow) bool {
 		key := treeRowKey(parentID, node.Issue.ID)
 		if expanded, ok := m.expandedInstances[key]; ok {
 			// When filtering, also check filter overrides
-			if m.filterText != "" {
+			if m.hasActiveFilterContext() {
 				if m.filterCollapsed != nil && m.filterCollapsed[node.Issue.ID] {
 					return false
 				}
@@ -54,7 +54,7 @@ func (m *App) isNodeExpandedInView(row graph.TreeRow) bool {
 		// Fall back to Node.Expanded if no per-instance state set yet
 	}
 
-	if m.filterText == "" {
+	if !m.hasActiveFilterContext() {
 		return node.Expanded
 	}
 	hasMatchingChild := false
@@ -120,7 +120,7 @@ func (m *App) expandNodeForView(row graph.TreeRow) {
 		node.Expanded = true
 	}
 
-	if m.filterText == "" {
+	if !m.hasActiveFilterContext() {
 		return
 	}
 	id := node.Issue.ID
@@ -155,7 +155,7 @@ func (m *App) collapseNodeForView(row graph.TreeRow) {
 		node.Expanded = false
 	}
 
-	if m.filterText == "" {
+	if !m.hasActiveFilterContext() {
 		return
 	}
 	id := node.Issue.ID

--- a/internal/ui/state_filter.go
+++ b/internal/ui/state_filter.go
@@ -7,6 +7,12 @@ import (
 	"abacus/internal/graph"
 )
 
+// hasActiveFilterContext reports whether tree rows are being filtered either by
+// text search or by non-default view mode.
+func (m *App) hasActiveFilterContext() bool {
+	return m.filterText != "" || m.viewMode != ViewModeAll
+}
+
 func nodeMatchesFilter(filterLower string, node *graph.Node) bool {
 	if filterLower == "" {
 		return true


### PR DESCRIPTION
## Summary
- fix manual collapse behavior when using `Active` or `Ready` view modes
- treat non-`All` view mode as an active filter context for expansion overrides
- add a regression test proving a parent with matching children can still be manually collapsed in `Active` mode

## Root cause
Tree traversal treated `viewMode != All` as filtered, but collapse/expand override state (`filterCollapsed` / `filterForcedExpanded`) was only tracked when `filterText` was non-empty. In Active/Ready mode this caused matching parents to auto-expand again immediately.

## Changes
- add `hasActiveFilterContext()` (`filterText != "" || viewMode != ViewModeAll`)
- use that helper in:
  - `isNodeExpandedInView`
  - `expandNodeForView`
  - `collapseNodeForView`
- add `TestViewModeActiveAllowsManualCollapseOfMatchingParent`

## Validation
- `go test ./internal/ui`
- `go test ./...`
