### PR TITLE
fix(sqlite): remove authority component from DSN to fix Windows startup

### DIFF
--- a/internal/beads/bd_sqlite.go
+++ b/internal/beads/bd_sqlite.go
@@ -46,19 +46,16 @@ func NewBdSQLiteClient(dbPath string, opts ...BdCLIOption) Client {
 }
 
 // buildBdSQLiteDSN creates a read-only WAL DSN for the given path.
+// Uses "file:<path>?..." without an authority component so that Windows drive
+// letters (e.g. C:/...) are not misinterpreted as network hosts by modernc.org/sqlite.
 func buildBdSQLiteDSN(dbPath string) string {
-	u := url.URL{
-		Scheme: "file",
-		Path:   filepath.ToSlash(dbPath),
-	}
 	q := url.Values{}
 	q.Set("mode", "ro")
 	q.Set("_journal_mode", "WAL")
 	q.Set("_busy_timeout", "3000")
 	q.Set("_foreign_keys", "on")
 	q.Set("cache", "shared")
-	u.RawQuery = q.Encode()
-	return u.String()
+	return "file:" + filepath.ToSlash(dbPath) + "?" + q.Encode()
 }
 
 func (c *bdSQLiteClient) openDB(ctx context.Context) (*sql.DB, error) {

--- a/internal/beads/bd_sqlite.go
+++ b/internal/beads/bd_sqlite.go
@@ -9,8 +9,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"net/url"
-	"path/filepath"
 	"strings"
 
 	_ "modernc.org/sqlite" // Pure Go SQLite driver, WAL-friendly
@@ -35,7 +33,7 @@ func NewBdSQLiteClient(dbPath string, opts ...BdCLIOption) Client {
 		// A valid dbPath is required for SQLite client.
 		panic("NewBdSQLiteClient requires a non-empty dbPath; use NewBdCLIClient for CLI-only operations")
 	}
-	dsn := buildBdSQLiteDSN(trimmed)
+	dsn := buildSQLiteDSN(trimmed)
 	// Ensure writes go to the same DB when the CLI is used for mutations.
 	opts = append(opts, WithBdDatabasePath(trimmed))
 	return &bdSQLiteClient{
@@ -43,19 +41,6 @@ func NewBdSQLiteClient(dbPath string, opts ...BdCLIOption) Client {
 		dsn:    dsn,
 		writer: NewBdCLIClient(opts...),
 	}
-}
-
-// buildBdSQLiteDSN creates a read-only WAL DSN for the given path.
-// Uses "file:<path>?..." without an authority component so that Windows drive
-// letters (e.g. C:/...) are not misinterpreted as network hosts by modernc.org/sqlite.
-func buildBdSQLiteDSN(dbPath string) string {
-	q := url.Values{}
-	q.Set("mode", "ro")
-	q.Set("_journal_mode", "WAL")
-	q.Set("_busy_timeout", "3000")
-	q.Set("_foreign_keys", "on")
-	q.Set("cache", "shared")
-	return "file:" + filepath.ToSlash(dbPath) + "?" + q.Encode()
 }
 
 func (c *bdSQLiteClient) openDB(ctx context.Context) (*sql.DB, error) {

--- a/internal/beads/bd_sqlite_test.go
+++ b/internal/beads/bd_sqlite_test.go
@@ -3,39 +3,10 @@ package beads
 import (
 	"context"
 	"database/sql"
-	"strings"
 	"testing"
 
 	_ "modernc.org/sqlite"
 )
-
-func TestBuildBdSQLiteDSN_NoDoubleSlash(t *testing.T) {
-	t.Parallel()
-
-	// On Windows, url.URL produces file://C:/... which modernc.org/sqlite
-	// interprets as a network host. The DSN must use file: without authority.
-	tests := []struct {
-		name   string
-		dbPath string
-	}{
-		{"unix path", "/home/user/.beads/beads.db"},
-		{"windows style path", "C:/Users/user/.beads/beads.db"},
-		{"relative path", "project/.beads/beads.db"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			dsn := buildBdSQLiteDSN(tt.dbPath)
-			if !strings.HasPrefix(dsn, "file:") {
-				t.Errorf("DSN must start with 'file:': %q", dsn)
-			}
-			// file:// means authority component present — breaks Windows drive letters
-			if strings.HasPrefix(dsn, "file://") {
-				t.Errorf("DSN must not use authority (file://): %q", dsn)
-			}
-		})
-	}
-}
 
 func TestBdSQLiteClient_Comments_NullCreatedAt(t *testing.T) {
 	t.Parallel()

--- a/internal/beads/bd_sqlite_test.go
+++ b/internal/beads/bd_sqlite_test.go
@@ -3,10 +3,39 @@ package beads
 import (
 	"context"
 	"database/sql"
+	"strings"
 	"testing"
 
 	_ "modernc.org/sqlite"
 )
+
+func TestBuildBdSQLiteDSN_NoDoubleSlash(t *testing.T) {
+	t.Parallel()
+
+	// On Windows, url.URL produces file://C:/... which modernc.org/sqlite
+	// interprets as a network host. The DSN must use file: without authority.
+	tests := []struct {
+		name   string
+		dbPath string
+	}{
+		{"unix path", "/home/user/.beads/beads.db"},
+		{"windows style path", "C:/Users/user/.beads/beads.db"},
+		{"relative path", "project/.beads/beads.db"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dsn := buildBdSQLiteDSN(tt.dbPath)
+			if !strings.HasPrefix(dsn, "file:") {
+				t.Errorf("DSN must start with 'file:': %q", dsn)
+			}
+			// file:// means authority component present — breaks Windows drive letters
+			if strings.HasPrefix(dsn, "file://") {
+				t.Errorf("DSN must not use authority (file://): %q", dsn)
+			}
+		})
+	}
+}
 
 func TestBdSQLiteClient_Comments_NullCreatedAt(t *testing.T) {
 	t.Parallel()

--- a/internal/beads/br_sqlite.go
+++ b/internal/beads/br_sqlite.go
@@ -83,17 +83,18 @@ func deriveWorkDirFromDBPath(dbPath string) string {
 // the four-slash form (file:////server/share/...) required by the SQLite URI spec.
 func buildSQLiteDSN(dbPath string) string {
 	slashed := filepath.ToSlash(dbPath)
+	escapedPath := (&url.URL{Path: slashed}).EscapedPath()
 	q := url.Values{}
 	q.Set("mode", "ro")
 	q.Set("_journal_mode", "WAL")
 	q.Set("_busy_timeout", "3000")
 	q.Set("_foreign_keys", "on")
 	q.Set("cache", "shared")
-	if strings.HasPrefix(slashed, "//") {
+	if strings.HasPrefix(escapedPath, "//") {
 		// UNC path: prepend "//" so the total prefix is "file:////" as required.
-		return "file://" + slashed + "?" + q.Encode()
+		return "file://" + escapedPath + "?" + q.Encode()
 	}
-	return "file:" + slashed + "?" + q.Encode()
+	return "file:" + escapedPath + "?" + q.Encode()
 }
 
 func (c *brSQLiteClient) openDB(ctx context.Context) (*sql.DB, error) {

--- a/internal/beads/br_sqlite.go
+++ b/internal/beads/br_sqlite.go
@@ -75,19 +75,16 @@ func deriveWorkDirFromDBPath(dbPath string) string {
 }
 
 // buildBrSQLiteDSN creates a read-only WAL DSN for the given path.
+// Uses "file:<path>?..." without an authority component so that Windows drive
+// letters (e.g. C:/...) are not misinterpreted as network hosts by modernc.org/sqlite.
 func buildBrSQLiteDSN(dbPath string) string {
-	u := url.URL{
-		Scheme: "file",
-		Path:   filepath.ToSlash(dbPath),
-	}
 	q := url.Values{}
 	q.Set("mode", "ro")
 	q.Set("_journal_mode", "WAL")
 	q.Set("_busy_timeout", "3000")
 	q.Set("_foreign_keys", "on")
 	q.Set("cache", "shared")
-	u.RawQuery = q.Encode()
-	return u.String()
+	return "file:" + filepath.ToSlash(dbPath) + "?" + q.Encode()
 }
 
 func (c *brSQLiteClient) openDB(ctx context.Context) (*sql.DB, error) {

--- a/internal/beads/br_sqlite.go
+++ b/internal/beads/br_sqlite.go
@@ -36,7 +36,7 @@ func NewBrSQLiteClient(dbPath string, opts ...BrCLIOption) Client {
 		// brCLIClient only implements Writer, not Client, so we can't fall back.
 		panic("NewBrSQLiteClient requires a non-empty dbPath; use NewBrCLIClient for CLI-only Writer operations")
 	}
-	dsn := buildBrSQLiteDSN(trimmed)
+	dsn := buildSQLiteDSN(trimmed)
 	// Ensure writes go to the same DB when the CLI is used for mutations.
 	opts = append(opts, WithBrDatabasePath(trimmed))
 	// Derive workDir from dbPath so br can discover the workspace.
@@ -74,17 +74,26 @@ func deriveWorkDirFromDBPath(dbPath string) string {
 	return ""
 }
 
-// buildBrSQLiteDSN creates a read-only WAL DSN for the given path.
-// Uses "file:<path>?..." without an authority component so that Windows drive
-// letters (e.g. C:/...) are not misinterpreted as network hosts by modernc.org/sqlite.
-func buildBrSQLiteDSN(dbPath string) string {
+// buildSQLiteDSN returns a read-only WAL SQLite URI for the given path.
+//
+// The URI uses the "file:<path>?..." form (no authority component) so that
+// Windows drive letters (e.g. C:/...) are not misinterpreted as network hosts
+// by modernc.org/sqlite. UNC paths (\\server\share\..., which filepath.ToSlash
+// normalises to //server/share/...) are prefixed with an extra "//" to produce
+// the four-slash form (file:////server/share/...) required by the SQLite URI spec.
+func buildSQLiteDSN(dbPath string) string {
+	slashed := filepath.ToSlash(dbPath)
 	q := url.Values{}
 	q.Set("mode", "ro")
 	q.Set("_journal_mode", "WAL")
 	q.Set("_busy_timeout", "3000")
 	q.Set("_foreign_keys", "on")
 	q.Set("cache", "shared")
-	return "file:" + filepath.ToSlash(dbPath) + "?" + q.Encode()
+	if strings.HasPrefix(slashed, "//") {
+		// UNC path: prepend "//" so the total prefix is "file:////" as required.
+		return "file://" + slashed + "?" + q.Encode()
+	}
+	return "file:" + slashed + "?" + q.Encode()
 }
 
 func (c *brSQLiteClient) openDB(ctx context.Context) (*sql.DB, error) {

--- a/internal/beads/br_sqlite_test.go
+++ b/internal/beads/br_sqlite_test.go
@@ -15,8 +15,17 @@ import (
 // The caller should clean up with t.TempDir() or defer cleanup.
 func testBrDB(t *testing.T) string {
 	t.Helper()
-	dir := t.TempDir()
-	dbPath := filepath.Join(dir, "test.db")
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	createTestBrDB(t, dbPath)
+	return dbPath
+}
+
+func createTestBrDB(t *testing.T, dbPath string) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+		t.Fatalf("create test db directory: %v", err)
+	}
 
 	db, err := sql.Open("sqlite", dbPath)
 	if err != nil {
@@ -72,8 +81,6 @@ func testBrDB(t *testing.T) string {
 	if _, err := db.Exec(schema); err != nil {
 		t.Fatalf("create schema: %v", err)
 	}
-
-	return dbPath
 }
 
 // seedTestData populates the test database with sample data.

--- a/internal/beads/br_sqlite_test.go
+++ b/internal/beads/br_sqlite_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	_ "modernc.org/sqlite"
@@ -633,6 +634,34 @@ func brFindSubstring(s, substr string) int {
 		}
 	}
 	return -1
+}
+
+func TestBuildBrSQLiteDSN_NoDoubleSlash(t *testing.T) {
+	t.Parallel()
+
+	// On Windows, url.URL produces file://C:/... which modernc.org/sqlite
+	// interprets as a network host. The DSN must use file: without authority.
+	tests := []struct {
+		name   string
+		dbPath string
+	}{
+		{"unix path", "/home/user/.beads/beads.db"},
+		{"windows style path", "C:/Users/user/.beads/beads.db"},
+		{"relative path", "project/.beads/beads.db"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dsn := buildBrSQLiteDSN(tt.dbPath)
+			if !strings.HasPrefix(dsn, "file:") {
+				t.Errorf("DSN must start with 'file:': %q", dsn)
+			}
+			// file:// means authority component present — breaks Windows drive letters
+			if strings.HasPrefix(dsn, "file://") {
+				t.Errorf("DSN must not use authority (file://): %q", dsn)
+			}
+		})
+	}
 }
 
 func TestNewBrSQLiteClient_PanicsOnEmptyPath(t *testing.T) {

--- a/internal/beads/br_sqlite_test.go
+++ b/internal/beads/br_sqlite_test.go
@@ -636,32 +636,68 @@ func brFindSubstring(s, substr string) int {
 	return -1
 }
 
-func TestBuildBrSQLiteDSN_NoDoubleSlash(t *testing.T) {
+func TestBuildSQLiteDSN(t *testing.T) {
 	t.Parallel()
 
-	// On Windows, url.URL produces file://C:/... which modernc.org/sqlite
-	// interprets as a network host. The DSN must use file: without authority.
-	tests := []struct {
-		name   string
-		dbPath string
-	}{
-		{"unix path", "/home/user/.beads/beads.db"},
-		{"windows style path", "C:/Users/user/.beads/beads.db"},
-		{"relative path", "project/.beads/beads.db"},
+	// requiredParams are the query parameters that must appear in every DSN.
+	type param struct{ key, val string }
+	required := []param{
+		{"mode", "ro"},
+		{"_journal_mode", "WAL"},
+		{"_busy_timeout", "3000"},
+		{"_foreign_keys", "on"},
+		{"cache", "shared"},
+	}
+	assertParams := func(t *testing.T, dsn string) {
+		t.Helper()
+		for _, p := range required {
+			if !strings.Contains(dsn, p.key+"="+p.val) {
+				t.Errorf("DSN missing %s=%s: %q", p.key, p.val, dsn)
+			}
+		}
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			dsn := buildBrSQLiteDSN(tt.dbPath)
-			if !strings.HasPrefix(dsn, "file:") {
-				t.Errorf("DSN must start with 'file:': %q", dsn)
-			}
-			// file:// means authority component present — breaks Windows drive letters
-			if strings.HasPrefix(dsn, "file://") {
-				t.Errorf("DSN must not use authority (file://): %q", dsn)
-			}
-		})
-	}
+	t.Run("unix absolute path", func(t *testing.T) {
+		dsn := buildSQLiteDSN("/home/user/.beads/beads.db")
+		if !strings.HasPrefix(dsn, "file:/home/user/.beads/beads.db?") {
+			t.Errorf("unexpected DSN: %q", dsn)
+		}
+		assertParams(t, dsn)
+	})
+
+	t.Run("windows drive letter", func(t *testing.T) {
+		dsn := buildSQLiteDSN("C:/Users/user/.beads/beads.db")
+		if !strings.HasPrefix(dsn, "file:C:/Users/user/.beads/beads.db?") {
+			t.Errorf("unexpected DSN: %q", dsn)
+		}
+		// Must not use authority component — that's what broke Windows
+		if strings.HasPrefix(dsn, "file://C") {
+			t.Errorf("DSN must not use authority for drive letter: %q", dsn)
+		}
+		assertParams(t, dsn)
+	})
+
+	t.Run("relative path", func(t *testing.T) {
+		dsn := buildSQLiteDSN("project/.beads/beads.db")
+		if !strings.HasPrefix(dsn, "file:project/.beads/beads.db?") {
+			t.Errorf("unexpected DSN: %q", dsn)
+		}
+		assertParams(t, dsn)
+	})
+
+	t.Run("UNC path", func(t *testing.T) {
+		// On Windows \\server\share\... becomes //server/share/... after filepath.ToSlash.
+		// SQLite URI spec requires file:////server/share/... (four slashes) for UNC paths;
+		// file://server/... would treat "server" as an authority host and fail to open.
+		dsn := buildSQLiteDSN("//server/share/.beads/beads.db")
+		if !strings.HasPrefix(dsn, "file:////server/share/.beads/beads.db?") {
+			t.Errorf("UNC DSN must use four-slash form (file:////): %q", dsn)
+		}
+		if strings.HasPrefix(dsn, "file://server") {
+			t.Errorf("DSN must not treat UNC host as authority: %q", dsn)
+		}
+		assertParams(t, dsn)
+	})
 }
 
 func TestNewBrSQLiteClient_PanicsOnEmptyPath(t *testing.T) {

--- a/internal/beads/sqlite_dsn_test.go
+++ b/internal/beads/sqlite_dsn_test.go
@@ -1,0 +1,62 @@
+package beads
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBuildSQLiteDSN_EscapesReservedPathCharacters(t *testing.T) {
+	t.Parallel()
+
+	dsn := buildSQLiteDSN("/tmp/project#1/.beads/beads?.db")
+
+	if !strings.HasPrefix(dsn, "file:/tmp/project%231/.beads/beads%3F.db?") {
+		t.Fatalf("reserved path characters must be escaped in DSN: %q", dsn)
+	}
+	if strings.Contains(dsn, "/tmp/project#1/.beads/beads?.db?") {
+		t.Fatalf("DSN must not include raw reserved characters in the path: %q", dsn)
+	}
+}
+
+func TestSQLiteClients_ListWithReservedCharactersInDBPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		newClient func(string) Client
+	}{
+		{
+			name: "br",
+			newClient: func(dbPath string) Client {
+				return NewBrSQLiteClient(dbPath)
+			},
+		},
+		{
+			name: "bd",
+			newClient: func(dbPath string) Client {
+				return NewBdSQLiteClient(dbPath)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			dbPath := filepath.Join(t.TempDir(), "project#1", ".beads", "beads#1.db")
+			createTestBrDB(t, dbPath)
+			seedTestData(t, dbPath)
+
+			issues, err := tt.newClient(dbPath).List(context.Background())
+			if err != nil {
+				t.Fatalf("List: %v", err)
+			}
+			if len(issues) != 3 {
+				t.Fatalf("got %d issues, want 3", len(issues))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #16 — Abacus fails to start on Windows with `SQL logic error: out of memory (1)`.

- `url.URL{Scheme:"file", Path:"C:/..."}` produces `file://C:/...`, where `//C:` is parsed as a network authority by `modernc.org/sqlite`, not a drive letter
- Replace both `buildBrSQLiteDSN` and `buildBdSQLiteDSN` with direct string concatenation: `"file:" + filepath.ToSlash(path) + "?" + query`
- This produces `file:C:/...` (no authority), which the driver handles correctly on all platforms

## Test plan

- [ ] New table-driven tests `TestBuildBrSQLiteDSN_NoDoubleSlash` and `TestBuildBdSQLiteDSN_NoDoubleSlash` assert DSN starts with `file:` but not `file://`
- [ ] `make check-test` passes (1293 tests)