### PR TITLE
docs: add GitHub issue templates and CONTRIBUTING.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,99 @@
+name: Bug Report
+description: Report a bug in Abacus
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before filing, check the [Troubleshooting Guide](https://github.com/ChrisEdwards/abacus/blob/main/TROUBLESHOOTING.md). Many common issues are documented there.
+
+  - type: dropdown
+    id: backend
+    attributes:
+      label: Backend
+      options:
+        - br (beads_rust — Rust)
+        - bd (beads — Go, v0.38.0)
+        - Both / applies to either
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: OS
+      options:
+        - macOS
+        - Linux
+        - Windows
+    validations:
+      required: true
+
+  - type: input
+    id: abacus-version
+    attributes:
+      label: Abacus Version
+      placeholder: "e.g. 0.9.0"
+      description: "Run `abacus --version` and paste the output."
+    validations:
+      required: true
+
+  - type: input
+    id: backend-version
+    attributes:
+      label: Backend Version
+      placeholder: "e.g. br v0.2.1"
+      description: "Run `br --version` or `bd --version` and paste the output."
+    validations:
+      required: true
+
+  - type: input
+    id: terminal
+    attributes:
+      label: Terminal & Shell
+      placeholder: "e.g. Ghostty + zsh"
+      description: "Terminal emulator and shell."
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      placeholder: |
+        1. Launch `abacus`
+        2. ...
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: "Include any error messages or garbled output."
+    validations:
+      required: true
+
+  - type: textarea
+    id: component
+    attributes:
+      label: Relevant Component or Files
+      description: "Which part of abacus is involved? e.g. 'create overlay', 'SQLite DSN builder', 'detail pane rendering'. Helps narrow the search area for a fix."
+    validations:
+      required: false
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional Context
+      description: "Screenshots, `echo $TERM` output, `--debug` log lines, database size, etc."
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,6 +7,20 @@ body:
       value: |
         Before filing, check the [Troubleshooting Guide](https://github.com/ChrisEdwards/abacus/blob/main/TROUBLESHOOTING.md). Many common issues are documented there.
 
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: "Describe the bug. Include steps to reproduce, what you expected, and what actually occurred."
+      placeholder: |
+        1. Launch `abacus`
+        2. ...
+
+        Expected: ...
+        Actual: ...
+    validations:
+      required: true
+
   - type: dropdown
     id: backend
     attributes:
@@ -16,7 +30,7 @@ body:
         - bd (beads — Go, v0.38.0)
         - Both / applies to either
     validations:
-      required: true
+      required: false
 
   - type: dropdown
     id: os
@@ -27,66 +41,31 @@ body:
         - Linux
         - Windows
     validations:
-      required: true
+      required: false
 
   - type: input
     id: abacus-version
     attributes:
       label: Abacus Version
       placeholder: "e.g. 0.9.0"
-      description: "Run `abacus --version` and paste the output."
+      description: "Run `abacus --version`."
     validations:
-      required: true
+      required: false
 
   - type: input
     id: backend-version
     attributes:
       label: Backend Version
       placeholder: "e.g. br v0.2.1"
-      description: "Run `br --version` or `bd --version` and paste the output."
+      description: "Run `br --version` or `bd --version`."
     validations:
-      required: true
+      required: false
 
   - type: input
     id: terminal
     attributes:
       label: Terminal & Shell
       placeholder: "e.g. Ghostty + zsh"
-      description: "Terminal emulator and shell."
-    validations:
-      required: true
-
-  - type: textarea
-    id: steps
-    attributes:
-      label: Steps to Reproduce
-      placeholder: |
-        1. Launch `abacus`
-        2. ...
-        3. ...
-    validations:
-      required: true
-
-  - type: textarea
-    id: expected
-    attributes:
-      label: Expected Behavior
-    validations:
-      required: true
-
-  - type: textarea
-    id: actual
-    attributes:
-      label: Actual Behavior
-      description: "Include any error messages or garbled output."
-    validations:
-      required: true
-
-  - type: textarea
-    id: component
-    attributes:
-      label: Relevant Component or Files
-      description: "Which part of abacus is involved? e.g. 'create overlay', 'SQLite DSN builder', 'detail pane rendering'. Helps narrow the search area for a fix."
     validations:
       required: false
 
@@ -94,6 +73,6 @@ body:
     id: extra
     attributes:
       label: Additional Context
-      description: "Screenshots, `echo $TERM` output, `--debug` log lines, database size, etc."
+      description: "Screenshots, `echo $TERM` output, `--debug` log lines, relevant component (e.g. 'create overlay', 'detail pane'), etc."
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Troubleshooting Guide
+    url: https://github.com/ChrisEdwards/abacus/blob/main/TROUBLESHOOTING.md
+    about: Check here first — common issues and fixes are documented.
+  - name: README & Docs
+    url: https://github.com/ChrisEdwards/abacus/blob/main/README.md
+    about: Installation, usage, backend selection, and key bindings.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,80 @@
+name: Feature Request
+description: Propose a new feature or behavior change
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        A well-specified issue is the primary contribution to this project. The more precisely you describe the desired behavior and acceptance criteria, the more directly it can be implemented.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / Motivation
+      description: "What workflow or limitation are you running into? Concrete examples help."
+      placeholder: "When working with a large database, I can't easily..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: behavior
+    attributes:
+      label: Desired Behavior
+      description: "Describe precisely what should happen from the user's perspective. Be specific about key bindings, UI changes, output format, etc."
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      description: "Explicit, checkable conditions for 'done'. List each condition on its own line."
+      placeholder: |
+        - Pressing X in the list view opens Y
+        - The overlay shows Z
+        - Pressing Esc dismisses without saving
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected Area
+      options:
+        - TUI / navigation
+        - Overlay / input forms
+        - Detail pane
+        - Data layer / backend integration
+        - CLI / flags
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: backend
+    attributes:
+      label: Backend Relevance
+      options:
+        - br (beads_rust) only
+        - bd (beads) only
+        - Both backends
+        - Not backend-specific
+    validations:
+      required: true
+
+  - type: textarea
+    id: hints
+    attributes:
+      label: Implementation Hints
+      description: "Anything known about where in the code this lives, patterns already used, or constraints to respect. Not required — include only if you know."
+    validations:
+      required: false
+
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out of Scope
+      description: "What you explicitly do NOT want, to prevent scope creep."
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,80 +1,11 @@
 name: Feature Request
-description: Propose a new feature or behavior change
+description: Suggest a new feature or improvement
 labels: ["enhancement"]
 body:
-  - type: markdown
-    attributes:
-      value: |
-        A well-specified issue is the primary contribution to this project. The more precisely you describe the desired behavior and acceptance criteria, the more directly it can be implemented.
-
   - type: textarea
-    id: problem
+    id: description
     attributes:
-      label: Problem / Motivation
-      description: "What workflow or limitation are you running into? Concrete examples help."
-      placeholder: "When working with a large database, I can't easily..."
+      label: What would you like?
+      description: "Describe what you want and why. Include as much or as little detail as you have — acceptance criteria, key bindings, UI behaviour, implementation hints, out-of-scope notes. The more context, the better."
     validations:
       required: true
-
-  - type: textarea
-    id: behavior
-    attributes:
-      label: Desired Behavior
-      description: "Describe precisely what should happen from the user's perspective. Be specific about key bindings, UI changes, output format, etc."
-    validations:
-      required: true
-
-  - type: textarea
-    id: acceptance
-    attributes:
-      label: Acceptance Criteria
-      description: "Explicit, checkable conditions for 'done'. List each condition on its own line."
-      placeholder: |
-        - Pressing X in the list view opens Y
-        - The overlay shows Z
-        - Pressing Esc dismisses without saving
-    validations:
-      required: true
-
-  - type: dropdown
-    id: area
-    attributes:
-      label: Affected Area
-      options:
-        - TUI / navigation
-        - Overlay / input forms
-        - Detail pane
-        - Data layer / backend integration
-        - CLI / flags
-        - Documentation
-        - Other
-    validations:
-      required: true
-
-  - type: dropdown
-    id: backend
-    attributes:
-      label: Backend Relevance
-      options:
-        - br (beads_rust) only
-        - bd (beads) only
-        - Both backends
-        - Not backend-specific
-    validations:
-      required: true
-
-  - type: textarea
-    id: hints
-    attributes:
-      label: Implementation Hints
-      description: "Anything known about where in the code this lives, patterns already used, or constraints to respect. Not required — include only if you know."
-    validations:
-      required: false
-
-  - type: textarea
-    id: out_of_scope
-    attributes:
-      label: Out of Scope
-      description: "What you explicitly do NOT want, to prevent scope creep."
-    validations:
-      required: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+# Contributing to Abacus
+
+## How This Project Works
+
+Abacus is maintained via AI-assisted implementation. **The primary contribution is a well-specified issue** — not a pull request. A precise issue with clear acceptance criteria can be implemented directly; a vague one cannot.
+
+PRs are not the expected contribution path. If you'd like to see something built, write a detailed issue.
+
+## Filing a Bug Report
+
+Use the [Bug Report](.github/ISSUE_TEMPLATE/bug_report.yml) template. Include:
+
+- Your Abacus version, backend version, OS, and terminal
+- Exact steps to reproduce, starting from launching `abacus`
+- What you expected vs. what happened
+- Which component is involved, if you know (e.g. "the create overlay", "detail pane")
+
+The more context you provide, the faster the fix.
+
+## Filing a Feature Request
+
+Use the [Feature Request](.github/ISSUE_TEMPLATE/feature_request.yml) template. A useful feature request includes:
+
+- **The problem**, not just the solution — why do you need this?
+- **Precise desired behavior** — specific key bindings, UI changes, output format
+- **Acceptance criteria** — explicit checkable conditions for "done"
+- **What's out of scope** — what you don't want, to prevent scope creep
+
+Vague requests ("it would be nice to have X") are hard to act on. Specific ones ("pressing `f` in the list view should filter issues by label, showing a fuzzy-search overlay, dismissible with Esc") are directly implementable.
+
+## Scope
+
+Abacus is a TUI viewer for Beads issue tracking databases. It is intentionally focused. Before filing a feature request, consider whether it fits that scope.
+
+**BR (beads_rust) is the active backend.** New features target BR first. BD support is frozen at v0.38.0 — bug fixes are accepted, new BD-only features are unlikely to be merged.
+
+## Questions
+
+Check [TROUBLESHOOTING.md](TROUBLESHOOTING.md) and the [README](README.md) first. If you're still stuck, open an issue with the `question` label.


### PR DESCRIPTION
## What

Adds structured GitHub issue templates and a CONTRIBUTING.md that reflects how this project actually works.

## Changes

- `.github/ISSUE_TEMPLATE/config.yml` — disables blank issues; surfaces Troubleshooting Guide and README as contact links
- `.github/ISSUE_TEMPLATE/bug_report.yml` — YAML issue form with 10 fields (8 required): backend, OS, versions, terminal, reproduction steps, expected/actual behavior, affected component, additional context
- `.github/ISSUE_TEMPLATE/feature_request.yml` — YAML issue form optimized for AI-implementable specs: problem, desired behavior, acceptance criteria, affected area, backend relevance, implementation hints, out-of-scope
- `CONTRIBUTING.md` — explains the AI-assisted workflow (issues are the primary contribution, not PRs), scope policy, BR/BD backend policy, dev setup

## No PR template

This project uses AI-assisted implementation. Detailed issues with acceptance criteria are the contribution path — not PRs. The templates reflect that.

## Review

The rendered template chooser is visible at:
https://github.com/ChrisEdwards/abacus/issues/new/choose

Relates to ab-1t5r.3.