### PR TITLE
docs: add contribution policies and fix br/bd casing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,14 +28,6 @@ Use the [Feature Request](.github/ISSUE_TEMPLATE/feature_request.yml) template. 
 
 Vague requests ("it would be nice to have X") are hard to act on. Specific ones ("pressing `f` in the list view should filter issues by label, showing a fuzzy-search overlay, dismissible with Esc") are directly implementable.
 
-## Proposals for Significant Changes
-
-For changes that affect the CLI interface, keybindings, data model, or architecture — **open an issue and wait for maintainer sign-off before writing code.** This prevents effort spent on changes that won't be accepted.
-
-What counts as significant: new commands or flags, changes to existing keybindings, backend protocol changes, anything that alters how `.beads/` data is read or written.
-
-What doesn't need a proposal: bug fixes, UI polish, documentation, performance improvements with no behaviour change.
-
 ## Scope
 
 Abacus is a **read/write TUI for Beads issue databases**. It is intentionally focused on that and nothing else.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,11 +28,35 @@ Use the [Feature Request](.github/ISSUE_TEMPLATE/feature_request.yml) template. 
 
 Vague requests ("it would be nice to have X") are hard to act on. Specific ones ("pressing `f` in the list view should filter issues by label, showing a fuzzy-search overlay, dismissible with Esc") are directly implementable.
 
+## Proposals for Significant Changes
+
+For changes that affect the CLI interface, keybindings, data model, or architecture — **open an issue and wait for maintainer sign-off before writing code.** This prevents effort spent on changes that won't be accepted.
+
+What counts as significant: new commands or flags, changes to existing keybindings, backend protocol changes, anything that alters how `.beads/` data is read or written.
+
+What doesn't need a proposal: bug fixes, UI polish, documentation, performance improvements with no behaviour change.
+
 ## Scope
 
-Abacus is a TUI viewer for Beads issue tracking databases. It is intentionally focused. Before filing a feature request, consider whether it fits that scope.
+Abacus is a **read/write TUI for Beads issue databases**. It is intentionally focused on that and nothing else.
 
-**BR (beads_rust) is the active backend.** New features target BR first. BD support is frozen at v0.38.0 — bug fixes are accepted, new BD-only features are unlikely to be merged.
+Out of scope: general project management features, non-Beads backends, web or GUI interfaces, features that duplicate what `br`/`bd` already provide on the command line.
+
+**br (beads_rust) is the active backend.** New features target br first. bd support is frozen at v0.38.0 — bug fixes are accepted, new bd-only features are unlikely to be merged.
+
+## How Issues Are Closed
+
+Issues are closed for the following reasons, indicated by a label:
+
+| Label | Meaning |
+|-------|---------|
+| `*duplicate` | Already tracked — see the linked issue |
+| `*as-designed` | The behaviour is intentional — a comment explains why |
+| `*not-reproducible` | Could not reproduce with the information provided |
+| `*out-of-scope` | Outside the project's stated scope |
+| `*needs-info` | Closed after requesting more information with no response (14 days) |
+
+If your issue was closed and you disagree, comment with additional context and it will be reconsidered.
 
 ## Questions
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A powerful terminal UI for visualizing and navigating [Beads](https://github.com
 
 Abacus transforms your Beads issue database into an interactive, hierarchical tree view right in your terminal. It provides an intuitive interface for exploring complex dependency graphs, viewing issue details, and understanding project structure at a glance.
 
-## Beads Backends: BD vs BR
+## Beads Backends: bd vs br
 
 Abacus supports two Beads backends:
 
@@ -47,8 +47,8 @@ Key differences:
 
 ### Support Policy
 
-- **BD support is frozen at version 0.38.0** — We will continue supporting BD indefinitely at this version, but will not add support for newer BD versions or features
-- **BR is the path forward** — New features and improvements will be developed for the BR backend
+- **bd support is frozen at version 0.38.0** — We will continue supporting bd indefinitely at this version, but will not add support for newer bd versions or features
+- **br is the path forward** — New features and improvements will be developed for the br backend
 - **100% JSONL compatible** — Both backends use the same `.beads/issues.jsonl` format, so your data is portable
 
 ## Preview
@@ -177,7 +177,7 @@ Key workflows are summarized below—run `abacus --help` anytime for the full fl
 
 ### Backend Selection
 
-Abacus supports both **beads (bd)** and **beads_rust (br)** backends. See [Beads Backends: BD vs BR](#beads-backends-bd-vs-br) for details on choosing between them.
+Abacus supports both **beads (bd)** and **beads_rust (br)** backends. See [Beads Backends: bd vs br](#beads-backends-bd-vs-br) for details on choosing between them.
 
 **Auto-detection:** On startup, abacus checks which binaries are available:
 - Only `br` on PATH → uses br automatically
@@ -204,7 +204,7 @@ beads:
 - **br**: v0.1.7 or later
 - **bd**: v0.30.0 to v0.38.0 (versions > 0.38.0 may work but are not officially supported)
 
-**Note on BD version support:** If you're using BD version > 0.38.0, Abacus will display a one-time informational notice. The software may still work, but we cannot guarantee compatibility with newer BD features or breaking changes. For the best experience, we recommend migrating to BR for new projects.
+**Note on bd version support:** If you're using bd version > 0.38.0, Abacus will display a one-time informational notice. The software may still work, but we cannot guarantee compatibility with newer bd features or breaking changes. For the best experience, we recommend migrating to br for new projects.
 
 ### Detail Panel Relationship Sections
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -20,7 +20,7 @@ Quick fixes for common Abacus issues.
 - **Version check failure**: Ensure your backend meets minimum version requirements:
   - `br`: v0.1.7 or later
   - `bd`: v0.30.0 to v0.38.0
-- **BD version > 0.38.0 warning**: This is informational only. Abacus officially supports BD up to v0.38.0; newer versions may work but are not guaranteed.
+- **bd version > 0.38.0 warning**: This is informational only. Abacus officially supports bd up to v0.38.0; newer versions may work but are not guaranteed.
 
 ## Runtime Problems
 


### PR DESCRIPTION
## What

Extends CONTRIBUTING.md with the remaining policy sections and fixes `BR`/`BD` uppercase references throughout the docs.

## Changes

**CONTRIBUTING.md** — three new sections:
- **Proposals for Significant Changes** — require an issue and maintainer sign-off before writing code for CLI/keybinding/data model changes (ab-1t5r.10)
- **Scope** — explicit statement of what abacus is and what's out of scope (ab-1t5r.8)
- **How Issues Are Closed** — table of closing reason labels with meanings, and an invitation to comment if the reporter disagrees (ab-1t5r.5, ab-1t5r.16)

**README.md / TROUBLESHOOTING.md** — `BR` → `br` and `BD` → `bd` throughout (section headings, support policy bullets, version notes)

Closes ab-1t5r.5, ab-1t5r.8, ab-1t5r.10, ab-1t5r.16.