### PR TITLE
Update dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,18 @@ updates:
       prefix: "deps"
     reviewers:
       - "ChrisEdwards"
+    groups:
+      gomod-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
Adds missing ecosystem coverage, enforces weekly schedule, 7-day cooldown, and grouped updates.

Changes:
- Added `groups` block to `gomod` entry for grouped dependency updates
- Added `github-actions` ecosystem entry (two workflow files use external actions but were not being tracked)